### PR TITLE
Missing `gitHubRepo`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.version>2.303.2</jenkins.version>
         <java.level>8</java.level>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
      </properties>
     <name>BMC DevOps for CFA</name>
     


### PR DESCRIPTION
This variable was used but not defined, potentially leading to corrupted POMs.

Not sure where you got this usage pattern from, but if you had used https://github.com/jenkinsci/archetypes this variable would have been set correctly from the start.